### PR TITLE
Remove unused test_helper files

### DIFF
--- a/ordering/test/test_helper.rb
+++ b/ordering/test/test_helper.rb
@@ -1,2 +1,0 @@
-require_relative '../lib/ordering'
-require_relative '../../test/support/test_case'

--- a/payments/test/test_helper.rb
+++ b/payments/test/test_helper.rb
@@ -1,2 +1,0 @@
-require_relative '../lib/payments'
-require_relative '../../test/support/test_case'


### PR DESCRIPTION
All the tests in the ordering and payments folders are using the
Rails test_helper, not these, so let's delete them to avoid confusion.