### PR TITLE
Remove unused require dependency

### DIFF
--- a/ordering/lib/ordering.rb
+++ b/ordering/lib/ordering.rb
@@ -1,22 +1,2 @@
 module Ordering
 end
-
-require_dependency 'ordering/add_item_to_basket'
-require_dependency 'ordering/fake_number_generator'
-require_dependency 'ordering/item_added_to_basket'
-require_dependency 'ordering/item_removed_from_basket'
-require_dependency 'ordering/number_generator'
-require_dependency 'ordering/on_add_item_to_basket'
-require_dependency 'ordering/on_remove_item_from_basket'
-require_dependency 'ordering/on_set_order_as_expired'
-require_dependency 'ordering/on_mark_order_as_paid'
-require_dependency 'ordering/on_submit_order'
-require_dependency 'ordering/order'
-require_dependency 'ordering/order_expired'
-require_dependency 'ordering/order_paid'
-require_dependency 'ordering/order_line'
-require_dependency 'ordering/order_submitted'
-require_dependency 'ordering/remove_item_from_basket'
-require_dependency 'ordering/set_order_as_expired'
-require_dependency 'ordering/mark_order_as_paid'
-require_dependency 'ordering/submit_order'

--- a/payments/lib/payments.rb
+++ b/payments/lib/payments.rb
@@ -1,7 +1,2 @@
 module Payments
 end
-
-require_dependency 'payments/payment_authorized'
-require_dependency 'payments/payment_captured'
-require_dependency 'payments/payment_released'
-require_dependency 'payments/payment'

--- a/payments/lib/payments/payment.rb
+++ b/payments/lib/payments/payment.rb
@@ -1,11 +1,11 @@
 module Payments
-  AlreadyAuthorized = Class.new(StandardError)
-  NotAuthorized = Class.new(StandardError)
-  AlreadyCaptured = Class.new(StandardError)
-  AlreadyReleased = Class.new(StandardError)
-
   class Payment
     include AggregateRoot
+
+    AlreadyAuthorized = Class.new(StandardError)
+    NotAuthorized = Class.new(StandardError)
+    AlreadyCaptured = Class.new(StandardError)
+    AlreadyReleased = Class.new(StandardError)
 
     def authorize(transaction_id, order_id)
       raise AlreadyAuthorized if authorized?

--- a/payments/test/payment_test.rb
+++ b/payments/test/payment_test.rb
@@ -17,7 +17,7 @@ module Payments
     end
 
     test 'should not allow for double authorization' do
-      assert_raises(Payments::AlreadyAuthorized) do
+      assert_raises(Payment::AlreadyAuthorized) do
         authorized_payment.authorize(transaction_id, order_id)
       end
     end
@@ -37,13 +37,13 @@ module Payments
     end
 
     test 'must not capture not authorized payment' do
-      assert_raises(Payments::NotAuthorized) do
+      assert_raises(Payment::NotAuthorized) do
         Payment.new.capture
       end
     end
 
     test 'should not allow for double capture' do
-      assert_raises(Payments::AlreadyCaptured) do
+      assert_raises(Payment::AlreadyCaptured) do
         captured_payment.capture
       end
     end
@@ -63,19 +63,19 @@ module Payments
     end
 
     test 'must not release not captured payment' do
-      assert_raises(Payments::AlreadyCaptured) do
+      assert_raises(Payment::AlreadyCaptured) do
         captured_payment.release
       end
     end
 
     test 'must not release not authorized payment' do
-      assert_raises(Payments::NotAuthorized) do
+      assert_raises(Payment::NotAuthorized) do
         Payment.new.release
       end
     end
 
     test 'should not allow for double release' do
-      assert_raises(Payments::AlreadyReleased) do
+      assert_raises(Payment::AlreadyReleased) do
         released_payment.release
       end
     end


### PR DESCRIPTION
Rails autoloading mechanisms are able to load these files just fine
because they follow the expected naming convention. Since we have no
need to load the files at any particular moment, they are instead loaded
and reloaded, on-demand.

After the first commit, there were some intermittently failing tests, which
showed there were some load order issues. Moving where Payment error
classes were defined resolved them.