### PR TITLE
Fix parameter order.

### DIFF
--- a/lib/cqrs.rb
+++ b/lib/cqrs.rb
@@ -9,13 +9,13 @@ class Cqrs
     @event_store.subscribe(subscriber, to: events)
   end
 
-  def register_command(command_handler, command, events)
-    @commands_to_events[command] = events
-    @command_bus.register(command_handler, command)
+  def register_command(command, command_handler, events)
+    @commands_to_events[command_handler] = events
+    @command_bus.register(command, command_handler)
   end
 
-  def register(command_handler, command)
-    @command_bus.register(command_handler, command)
+  def register(command, command_handler)
+    @command_bus.register(command, command_handler)
   end
 
   def run(command)


### PR DESCRIPTION
The order of parameters seems to be wrong right now within the `Cqrs` class. 
The data is correct but the names are not.

This is what I get when starting the app:

![Captura de tela de 2021-08-07 16-42-34](https://user-images.githubusercontent.com/34602039/128612154-772aed26-2d64-46e0-9fea-714819aa94de.png)

Where `Pricing::AddItemToBasket` is a command (not a command handler):

![Captura de tela de 2021-08-07 16-41-31](https://user-images.githubusercontent.com/34602039/128612167-5485ce87-7180-46ab-8ec4-1f654ccbfd3e.png)

And `Pricing::OnAddItemToBasket` is the command handler (not a command):

![Captura de tela de 2021-08-07 16-40-56](https://user-images.githubusercontent.com/34602039/128612197-4e40a385-7d62-4247-a2d8-117d27342367.png)

This PR contains a small fix for that both for `#register_command` and `#register`. :+1: 
Let me know if I got it wrong. Thanks!